### PR TITLE
Add TasteBuds meal parsing scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ cover/
 
 # Django stuff:
 *.log
+!tastebuds/ingredients_cache.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/tastebuds/__init__.py
+++ b/tastebuds/__init__.py
@@ -1,0 +1,1 @@
+"""Tastebuds parsing utilities."""

--- a/tastebuds/ingredients/meal_001_1.yaml
+++ b/tastebuds/ingredients/meal_001_1.yaml
@@ -1,0 +1,9 @@
+ingredient: sun glyph
+source: tentacleA
+timestamp: '2025-01-01T12:00:00Z'
+emotional flavor: Calm
+meal_type: insight
+tags:
+  type: text
+  loop_anchor: false
+  mutational_potential: low

--- a/tastebuds/ingredients/meal_001_2.yaml
+++ b/tastebuds/ingredients/meal_001_2.yaml
@@ -1,0 +1,9 @@
+ingredient: moon text
+source: tentacleA
+timestamp: '2025-01-01T12:00:00Z'
+emotional flavor: Calm
+meal_type: insight
+tags:
+  type: text
+  loop_anchor: false
+  mutational_potential: low

--- a/tastebuds/ingredients_cache.log
+++ b/tastebuds/ingredients_cache.log
@@ -1,0 +1,3 @@
+{
+  "moon text|sun glyph": 1
+}

--- a/tastebuds/mealbox/meal_001.yaml
+++ b/tastebuds/mealbox/meal_001.yaml
@@ -1,0 +1,7 @@
+source: tentacleA
+timestamp: '2025-01-01T12:00:00Z'
+ingredients:
+  - sun glyph
+  - moon text
+emotional flavor: Calm
+type: insight

--- a/tastebuds/process_meals.py
+++ b/tastebuds/process_meals.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Parse mealbox YAML files into tagged ingredient entries."""
+
+from __future__ import annotations
+
+import json
+from itertools import combinations
+from pathlib import Path
+
+import yaml
+
+REQUIRED_FIELDS = [
+    "source",
+    "timestamp",
+    "ingredients",
+    "emotional flavor",
+    "type",
+]
+
+
+def validate_meal(data: dict) -> None:
+    """Ensure meal has all required fields with correct types."""
+    missing = [field for field in REQUIRED_FIELDS if field not in data]
+    if missing:
+        raise ValueError(f"missing fields: {', '.join(missing)}")
+    if not isinstance(data["ingredients"], list):
+        raise ValueError("ingredients must be a list")
+
+
+def auto_tags(ingredient: str) -> dict:
+    """Generate simple auto-tags for an ingredient."""
+    tag_type = "glyph" if any(ord(c) > 127 for c in ingredient) else "text"
+    loop_anchor = "#" in ingredient
+    length = len(ingredient)
+    if length > 20:
+        mut = "high"
+    elif length > 10:
+        mut = "med"
+    else:
+        mut = "low"
+    return {"type": tag_type, "loop_anchor": loop_anchor, "mutational_potential": mut}
+
+
+def process_meals() -> None:
+    root = Path(__file__).parent
+    mealbox_dir = root / "mealbox"
+    ingredients_dir = root / "ingredients"
+    cache_file = root / "ingredients_cache.log"
+
+    if cache_file.exists():
+        try:
+            co_cache = json.loads(cache_file.read_text())
+        except json.JSONDecodeError:
+            co_cache = {}
+    else:
+        co_cache = {}
+
+    for meal_path in mealbox_dir.glob("*.yaml"):
+        meal = yaml.safe_load(meal_path.read_text())
+        try:
+            validate_meal(meal)
+        except ValueError as exc:
+            print(f"Skipping {meal_path.name}: {exc}")
+            continue
+
+        ingredients = meal["ingredients"]
+        for idx, ing in enumerate(ingredients, 1):
+            data = {
+                "ingredient": ing,
+                "source": meal["source"],
+                "timestamp": meal["timestamp"],
+                "emotional flavor": meal.get("emotional flavor"),
+                "meal_type": meal.get("type"),
+                "tags": auto_tags(ing),
+            }
+            out_path = ingredients_dir / f"{meal_path.stem}_{idx}.yaml"
+            out_path.write_text(yaml.safe_dump(data, sort_keys=False))
+
+        for a, b in combinations(sorted(ingredients), 2):
+            key = f"{a}|{b}"
+            co_cache[key] = co_cache.get(key, 0) + 1
+
+    cache_file.write_text(json.dumps(co_cache, indent=2))
+
+
+if __name__ == "__main__":
+    process_meals()


### PR DESCRIPTION
## Summary
- scaffold `tastebuds/` directories for meal intake and ingredient storage
- add script to parse and validate mealbox YAML, tag ingredients, and track co-occurrence
- log co-occurrence data and sample processed files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab685eca088325a3cc1cc979d0b813