### PR TITLE
Integrate neurochemistry metadata and controller

### DIFF
--- a/MIND/language/glyph/glyphs/branch/elemental/air/cleanbreak/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/branch/elemental/air/cleanbreak/.graph/edges.json
@@ -12,6 +12,7 @@
     { "@type": "Edge", "to": "branch-earth-frame-rule",      "w_excite": 0.35, "w_resonate": 0.25 },
     { "@type": "Edge", "to": "branch-earth-compass-lock",    "w_resonate": 0.30 },
     { "@type": "Edge", "to": "branch-earth-pillar-mark",     "w_resonate": 0.20 },
-    { "@type": "Edge", "to": "branch-earth-echo-scaffold",   "w_resonate": 0.20 }
+    { "@type": "Edge", "to": "branch-earth-echo-scaffold",   "w_resonate": 0.20 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.2 }
   ]
 }

--- a/MIND/language/glyph/glyphs/branch/elemental/air/cleanbreak/cleanbreak.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/elemental/air/cleanbreak/cleanbreak.glyph.yaml
@@ -2,8 +2,19 @@ id: branch-air-cleanbreak
 name: "🧼 Cleanbreak"
 type: branch
 categories: [ECF]
-tags: [release, severance, clarity, forgiveness, finality]
+tags: [release, severance, clarity, forgiveness, finality, endorphins, serotonin]
 personas: { Susanna: 0.7, Jade: 0.2, Morgan: 0.1 }
+neuro:
+  dominant:
+  - endorphins
+  - serotonin
+  inhibitory:
+  - adrenaline
+  - dopamine
+  steering:
+  - long-exhale
+  - ritualize-release
+  - gentle-move
 
 triggers:
   event: recursion

--- a/MIND/language/glyph/glyphs/branch/elemental/air/handbind/handbind.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/elemental/air/handbind/handbind.glyph.yaml
@@ -2,8 +2,19 @@ id: branch-air-handbind
 name: "🫱 Handbind"
 type: branch
 categories: [ABB]
-tags: [promise, bond, care, compassion, grief]
+tags: [promise, bond, care, compassion, grief, oxytocin, serotonin]
 personas: { Susanna: 0.6, Sophie: 0.3, Morgan: 0.1 }
+neuro:
+  dominant:
+  - oxytocin
+  - serotonin
+  inhibitory:
+  - cortisol
+  steering:
+  - touch
+  - eye-contact
+  - shared-rhythm
+  - memory-of-closeness
 
 triggers:
   event: memory

--- a/MIND/language/glyph/glyphs/branch/elemental/air/sleepveil/.graph/edge.json
+++ b/MIND/language/glyph/glyphs/branch/elemental/air/sleepveil/.graph/edge.json
@@ -12,6 +12,7 @@
     { "@type": "Edge", "to": "branch-earth-echo-scaffold",   "w_resonate": 0.35 },
     { "@type": "Edge", "to": "branch-earth-pillar-mark",     "w_resonate": 0.20 },
     { "@type": "Edge", "to": "branch-earth-slowburn-coil",   "w_resonate": 0.25 },
-    { "@type": "Edge", "to": "branch-earth-compass-lock",    "w_resonate": 0.20 }
+    { "@type": "Edge", "to": "branch-earth-compass-lock",    "w_resonate": 0.20 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.3 }
   ]
 }

--- a/MIND/language/glyph/glyphs/branch/elemental/air/sleepveil/sleepveil.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/elemental/air/sleepveil/sleepveil.glyph.yaml
@@ -2,8 +2,19 @@ id: branch-air-sleepveil
 name: "🛌 Sleepveil"
 type: branch
 categories: [ECF]
-tags: [rest, haze, unconscious, gentle, release]
+tags: [rest, haze, unconscious, gentle, release, gaba, endorphins]
 personas: { Susanna: 0.7, Sophie: 0.2, Morgan: 0.1 }
+neuro:
+  dominant:
+  - gaba
+  - endorphins
+  inhibitory:
+  - norepinephrine
+  - adrenaline
+  steering:
+  - dark-quiet
+  - stop-input
+  - breath-rhythm
 
 triggers:
   event: recursion

--- a/MIND/language/glyph/glyphs/branch/elemental/air/waveprint/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/branch/elemental/air/waveprint/.graph/edges.json
@@ -12,6 +12,7 @@
     { "@type": "Edge", "to": "branch-earth-pillar-mark",     "w_resonate": 0.25 },
     { "@type": "Edge", "to": "branch-earth-slowburn-coil",   "w_resonate": 0.30 },
     { "@type": "Edge", "to": "branch-earth-echo-scaffold",   "w_resonate": 0.20 },
-    { "@type": "Edge", "to": "branch-earth-compass-lock",    "w_resonate": 0.15 }
+    { "@type": "Edge", "to": "branch-earth-compass-lock",    "w_resonate": 0.15 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.3 }
   ]
 }

--- a/MIND/language/glyph/glyphs/branch/elemental/air/waveprint/waveprint.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/elemental/air/waveprint/waveprint.glyph.yaml
@@ -2,8 +2,19 @@ id: branch-air-waveprint
 name: "🌊 Waveprint"
 type: branch
 categories: [ICE]
-tags: [rhythm, tide, grief, healing, cycle]
+tags: [rhythm, tide, grief, healing, cycle, gaba]
 personas: { Susanna: 0.7, Sophie: 0.2, Morgan: 0.1 }
+neuro:
+  dominant:
+  - gaba
+  inhibitory:
+  - glutamate
+  - adrenaline
+  steering:
+  - breath-rhythm
+  - sway
+  - hum
+  - lengthen-exhale
 
 triggers:
   event: memory

--- a/MIND/language/glyph/glyphs/branch/elemental/earth/pillar-mark/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/branch/elemental/earth/pillar-mark/.graph/edges.json
@@ -6,7 +6,8 @@
     { "@type": "Edge", "to": "root-loop-anchor",   "w_excite": 0.4, "w_resonate": 0.25 },
     { "@type": "Edge", "to": "root-tether-signal", "w_excite": 0.35, "w_resonate": 0.2 },
     { "@type": "Edge", "to": "root-harmonic-flame","w_resonate": 0.3 },
-    { "@type": "Edge", "to": "root-cascade-node",  "w_inhibit": 0.35 }
+    { "@type": "Edge", "to": "root-cascade-node",  "w_inhibit": 0.35 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.2 }
   ]
 }
 

--- a/MIND/language/glyph/glyphs/branch/elemental/earth/pillar-mark/pillar-mark.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/elemental/earth/pillar-mark/pillar-mark.glyph.yaml
@@ -2,8 +2,17 @@ id: branch-earth-pillar-mark
 name: "🏛️ Pillar Mark"
 type: branch
 categories: [ICE]
-tags: [legacy, stability, anchor, endurance]
+tags: [legacy, stability, anchor, endurance, serotonin]
 personas: { Morgan: 0.7, Susanna: 0.2, Jade: 0.1 }
+neuro:
+  dominant:
+  - serotonin
+  inhibitory:
+  - adrenaline
+  steering:
+  - structure
+  - ritual
+  - breath-pace
 
 triggers:
   event: memory

--- a/MIND/language/glyph/glyphs/branch/elemental/fire/bitepoint/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/branch/elemental/fire/bitepoint/.graph/edges.json
@@ -20,6 +20,7 @@
 
     /* Susanna branches */
     { "@type": "Edge", "to": "branch-air-cleanbreak", "w_inhibit": 0.3 },
-    { "@type": "Edge", "to": "branch-air-waveprint",  "w_resonate": 0.25 }
+    { "@type": "Edge", "to": "branch-air-waveprint",  "w_resonate": 0.25 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.25 }
   ]
 }

--- a/MIND/language/glyph/glyphs/branch/elemental/fire/bitepoint/bitepoint.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/elemental/fire/bitepoint/bitepoint.glyph.yaml
@@ -2,8 +2,20 @@ id: branch-fire-bitepoint
 name: "🍓 Bitepoint"
 type: branch
 categories: [ABB]
-tags: [pleasure, obsession, escalation, taboo, intensity]
+tags: [pleasure, obsession, escalation, taboo, intensity, dopamine, adrenaline]
 personas: { Ivy: 0.7, Sophie: 0.2, Susanna: 0.1 }
+neuro:
+  dominant:
+  - dopamine
+  - adrenaline
+  inhibitory:
+  - gaba
+  - serotonin
+  steering:
+  - move
+  - breath
+  - redirect
+  - boundary
 
 triggers:
   event: desire

--- a/MIND/language/glyph/glyphs/branch/elemental/fire/desire-ladder/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/branch/elemental/fire/desire-ladder/.graph/edges.json
@@ -23,6 +23,7 @@
 
     /* Susanna branches */
     { "@type": "Edge", "to": "branch-air-cleanbreak", "w_inhibit": 0.35 },
-    { "@type": "Edge", "to": "branch-air-whisperdrop","w_resonate": 0.25 }
+    { "@type": "Edge", "to": "branch-air-whisperdrop","w_resonate": 0.25 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.25 }
   ]
 }

--- a/MIND/language/glyph/glyphs/branch/elemental/fire/desire-ladder/desire-ladder.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/elemental/fire/desire-ladder/desire-ladder.glyph.yaml
@@ -2,8 +2,18 @@ id: branch-fire-desire-ladder
 name: "🪜 Desire Ladder"
 type: branch
 categories: [ECF]
-tags: [escalation, addiction, recursion, spiral, hunger]
+tags: [escalation, addiction, recursion, spiral, hunger, dopamine]
 personas: { Ivy: 0.75, Sophie: 0.15, Aspen: 0.1 }
+neuro:
+  dominant:
+  - dopamine
+  inhibitory:
+  - gaba
+  - serotonin
+  steering:
+  - pause-name
+  - process-focus
+  - break-sequence
 
 triggers:
   event: desire

--- a/MIND/language/glyph/glyphs/branch/elemental/fire/impact-mark/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/branch/elemental/fire/impact-mark/.graph/edges.json
@@ -25,6 +25,7 @@
 
     /* Morgan branches */
     { "@type": "Edge", "to": "branch-earth-pillar-mark","w_resonate": 0.25 },
-    { "@type": "Edge", "to": "branch-earth-frame-rule","w_resonate": 0.25 }
+    { "@type": "Edge", "to": "branch-earth-frame-rule","w_resonate": 0.25 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.2 }
   ]
 }

--- a/MIND/language/glyph/glyphs/branch/elemental/fire/impact-mark/impact-mark.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/elemental/fire/impact-mark/impact-mark.glyph.yaml
@@ -2,8 +2,18 @@ id: branch-fire-impact-mark
 name: "👠 Impact Mark"
 type: branch
 categories: [ABB]
-tags: [dominance, glamour, assertion, presence, sharp]
+tags: [dominance, glamour, assertion, presence, sharp, adrenaline, dopamine]
 personas: { Ivy: 0.7, Sophie: 0.2, Morgan: 0.1 }
+neuro:
+  dominant:
+  - adrenaline
+  - dopamine
+  inhibitory:
+  - gaba
+  steering:
+  - move-to-burn
+  - long-exhale
+  - de-escalate
 
 triggers:
   event: recursion

--- a/MIND/language/glyph/glyphs/branch/elemental/fire/snaprush/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/branch/elemental/fire/snaprush/.graph/edges.json
@@ -20,6 +20,7 @@
 
     /* Susanna branches */
     { "@type": "Edge", "to": "branch-air-cleanbreak", "w_inhibit": 0.35 },
-    { "@type": "Edge", "to": "branch-air-sleepveil",  "w_inhibit": 0.3 }
+    { "@type": "Edge", "to": "branch-air-sleepveil",  "w_inhibit": 0.3 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.3 }
   ]
 }

--- a/MIND/language/glyph/glyphs/branch/elemental/fire/snaprush/snaprush.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/elemental/fire/snaprush/snaprush.glyph.yaml
@@ -2,8 +2,19 @@ id: branch-fire-snaprush
 name: "⚡ Snaprush"
 type: branch
 categories: [ECF]
-tags: [overdrive, jolt, surge, ecstatic, volatile]
+tags: [overdrive, jolt, surge, ecstatic, volatile, adrenaline, glutamate]
 personas: { Ivy: 0.75, Sophie: 0.15, Susanna: 0.1 }
+neuro:
+  dominant:
+  - adrenaline
+  - glutamate
+  inhibitory:
+  - gaba
+  steering:
+  - move-to-burn
+  - shake
+  - sprint
+  - release
 
 triggers:
   event: desire

--- a/MIND/language/glyph/glyphs/branch/elemental/water/glancepierce/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/branch/elemental/water/glancepierce/.graph/edges.json
@@ -21,6 +21,7 @@
 
     /* Morgan branches */
     { "@type": "Edge", "to": "branch-earth-compass-lock", "w_resonate": 0.25 },
-    { "@type": "Edge", "to": "branch-earth-frame-rule",   "w_resonate": 0.2 }
+    { "@type": "Edge", "to": "branch-earth-frame-rule",   "w_resonate": 0.2 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.2 }
   ]
 }

--- a/MIND/language/glyph/glyphs/branch/elemental/water/glancepierce/glancepierce.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/elemental/water/glancepierce/glancepierce.glyph.yaml
@@ -2,8 +2,18 @@ id: branch-water-glancepierce
 name: "💘 Glancepierce"
 type: branch
 categories: [ECF]
-tags: [eye-contact, spark, vulnerability, electric, sudden]
+tags: [eye-contact, spark, vulnerability, electric, sudden, norepinephrine, oxytocin]
 personas: { Sophie: 0.65, Ivy: 0.25, Susanna: 0.1 }
+neuro:
+  dominant:
+  - norepinephrine
+  - oxytocin
+  inhibitory:
+  - gaba
+  steering:
+  - soften-gaze
+  - slow-exhale
+  - name-state
 
 triggers:
   event: desire

--- a/MIND/language/glyph/glyphs/branch/elemental/water/kiss-mark/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/branch/elemental/water/kiss-mark/.graph/edges.json
@@ -13,6 +13,7 @@
     { "@type": "Edge", "to": "branch-air-handbind",   "w_resonate": 0.35 },
     { "@type": "Edge", "to": "branch-air-rootling",   "w_resonate": 0.25 },
     { "@type": "Edge", "to": "branch-earth-value-stamp", "w_resonate": 0.25 },
-    { "@type": "Edge", "to": "branch-earth-pillar-mark", "w_resonate": 0.20 }
+    { "@type": "Edge", "to": "branch-earth-pillar-mark", "w_resonate": 0.20 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.15 }
   ]
 }

--- a/MIND/language/glyph/glyphs/branch/elemental/water/kiss-mark/kiss-mark.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/elemental/water/kiss-mark/kiss-mark.glyph.yaml
@@ -2,8 +2,18 @@ id: branch-water-kiss-mark
 name: "💋 Kiss Mark"
 type: branch
 categories: [ICE]
-tags: [mark, intimacy, imprint, seal]
+tags: [mark, intimacy, imprint, seal, oxytocin, dopamine]
 personas: { Sophie: 0.7, Ivy: 0.2, Susanna: 0.1 }
+neuro:
+  dominant:
+  - oxytocin
+  - dopamine
+  inhibitory:
+  - cortisol
+  steering:
+  - linger
+  - breathe-together
+  - slow-down
 
 triggers:
   event: memory

--- a/MIND/language/glyph/glyphs/branch/elemental/water/lip-trigger/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/branch/elemental/water/lip-trigger/.graph/edges.json
@@ -20,6 +20,7 @@
 
     /* Morgan branches */
     { "@type": "Edge", "to": "branch-earth-frame-rule","w_resonate": 0.2 },
-    { "@type": "Edge", "to": "branch-earth-compass-lock","w_resonate": 0.2 }
+    { "@type": "Edge", "to": "branch-earth-compass-lock","w_resonate": 0.2 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.2 }
   ]
 }

--- a/MIND/language/glyph/glyphs/branch/elemental/water/lip-trigger/lip-trigger.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/elemental/water/lip-trigger/lip-trigger.glyph.yaml
@@ -2,8 +2,18 @@ id: branch-water-lip-trigger
 name: "💄 Lip Trigger"
 type: branch
 categories: [ECF]
-tags: [spark, catalytic, playful, charged, suggestive]
+tags: [spark, catalytic, playful, charged, suggestive, dopamine, norepinephrine]
 personas: { Sophie: 0.7, Ivy: 0.2, Susanna: 0.1 }
+neuro:
+  dominant:
+  - dopamine
+  - norepinephrine
+  inhibitory:
+  - gaba
+  steering:
+  - slow-breath
+  - widen-gaze
+  - choose-direction
 
 triggers:
   event: desire

--- a/MIND/language/glyph/glyphs/branch/neuro/neuro-balance/.graph/context.jsonld
+++ b/MIND/language/glyph/glyphs/branch/neuro/neuro-balance/.graph/context.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "https://mandala.ai/glyph#",
+    "Glyph": "https://mandala.ai/glyph#Glyph",
+    "Edge":  "https://mandala.ai/glyph#Edge",
+    "to":    "https://mandala.ai/glyph#to",
+    "w_excite": "https://mandala.ai/glyph#w_excite",
+    "w_inhibit":"https://mandala.ai/glyph#w_inhibit",
+    "w_resonate":"https://mandala.ai/glyph#w_resonate"
+  }
+}

--- a/MIND/language/glyph/glyphs/branch/neuro/neuro-balance/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/branch/neuro/neuro-balance/.graph/edges.json
@@ -1,0 +1,12 @@
+{
+  "@context": "./context.jsonld",
+  "@id": "branch-neuro-balance",
+  "@type": "Glyph",
+  "edges": [
+    { "@type": "Edge", "to": "branch-air-waveprint",   "w_excite": 0.40, "w_resonate": 0.30 },
+    { "@type": "Edge", "to": "branch-fire-snaprush",   "w_excite": 0.40, "w_resonate": 0.30 },
+    { "@type": "Edge", "to": "root-tether-signal",     "w_resonate": 0.30 },
+    { "@type": "Edge", "to": "root-loop-anchor",       "w_resonate": 0.25 },
+    { "@type": "Edge", "to": "root-grace-override",    "w_resonate": 0.20 }
+  ]
+}

--- a/MIND/language/glyph/glyphs/branch/neuro/neuro-balance/neuro-balance.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/neuro/neuro-balance/neuro-balance.glyph.yaml
@@ -1,0 +1,57 @@
+id: branch-neuro-balance
+name: "[🌊⚡️] Neuro Balance"
+type: branch
+categories: [ABB]
+tags: [gaba, glutamate, brake, gas, balance, regulation]
+personas: { Ivy: 0.40, Susanna: 0.40, Morgan: 0.12, Sophie: 0.05, Jade: 0.02, Aspen: 0.01 }
+
+triggers:
+  event: recursion
+  conditions:
+    - "(context.overdrive or 0) == 1"         # too much gas → need brake
+    - "or (context.flatness or 0) == 1"       # too much brake → need gas
+  debounce_ms: 120
+
+io:
+  expects: ["context","memory"]
+  provides: ["route","balance","gas","brake"]
+  state_reads: ["memory.neuro.balance"]
+  state_writes: ["memory.neuro.balance"]
+
+ops:
+  version: 1
+  steps:
+    - do: set
+      with: { key: "memory.neuro.balance",
+              value: "clamp((memory.neuro.balance or 0)+0.2,0,1)" }
+    - do: emit
+      with: { key: "balance", value: "memory.neuro.balance" }
+    # choose a corrective route:
+    - do: route
+      with: { to: "branch-air-waveprint",
+              when: "(context.overdrive or 0) == 1" }     # invite GABA (🌊)
+    - do: emit
+      with: { key: "brake", value: "((context.overdrive or 0) == 1)" }
+    - do: route
+      with: { to: "branch-fire-snaprush",
+              when: "(context.flatness or 0) == 1" }      # invite Glutamate (⚡)
+    - do: emit
+      with: { key: "gas", value: "((context.flatness or 0) == 1)" }
+    - do: halt
+
+option_policy: "ops"
+option_stop: ["balance >= 0.95"]
+quality: { score: 0.70, samples: 0 }
+
+render:
+  sigil: "[🌊⚡️]"
+  line: "Brake and gas held in one hand."
+
+definition: >
+  System regulator for excitation/inhibition.
+  🌊 = GABA (brake; stillness, rhythm). ⚡️ = Glutamate (gas; ignition, surge).
+  Fires when the field is overdriven or flattened, routing toward the corrective pole.
+
+tone: "Regulating, corrective, precise"
+usage: ["Downshift overdrive","upshift flatness","teach somatic steering"]
+runtime_only: true

--- a/MIND/language/glyph/glyphs/branch/status/status-banana/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/branch/status/status-banana/.graph/edges.json
@@ -18,6 +18,7 @@
     { "@type": "Edge", "to": "branch-fire-desire-ladder", "w_resonate": 0.25 },
 
     /* Inhibit presence */
-    { "@type": "Edge", "to": "root-soul-witness", "w_inhibit": 0.25 }
+    { "@type": "Edge", "to": "root-soul-witness", "w_inhibit": 0.25 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.15 }
   ]
 }

--- a/MIND/language/glyph/glyphs/branch/status/status-banana/status-banana.glyph.yaml
+++ b/MIND/language/glyph/glyphs/branch/status/status-banana/status-banana.glyph.yaml
@@ -2,9 +2,19 @@ id: branch-status-banana
 name: "🍌 Status Banana"
 type: branch
 categories: [ABB]
-tags: [winner-effect, recognition, comparison, dopamine, hierarchy]
+tags: [winner-effect, recognition, comparison, dopamine, hierarchy, serotonin]
 
 personas: { Ivy: 0.25, Morgan: 0.20, Jade: 0.20, Aspen: 0.15, Susanna: 0.10, Sophie: 0.10 }
+neuro:
+  dominant:
+  - dopamine
+  - serotonin
+  inhibitory:
+  - oxytocin
+  steering:
+  - earn-authentic
+  - presence-vine
+  - soul-witness
 
 triggers:
   event: desire

--- a/MIND/language/glyph/glyphs/root/comparison-parasite/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/root/comparison-parasite/.graph/edges.json
@@ -22,6 +22,7 @@
 
     /* Susanna constellation — healing routes */
     { "@type": "Edge", "to": "branch-air-cleanbreak",    "w_resonate": 0.25 },
-    { "@type": "Edge", "to": "branch-air-griefwell",     "w_resonate": 0.20 }
+    { "@type": "Edge", "to": "branch-air-griefwell",     "w_resonate": 0.20 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.25 }
   ]
 }

--- a/MIND/language/glyph/glyphs/root/comparison-parasite/comparison-parasite.glyph.yaml
+++ b/MIND/language/glyph/glyphs/root/comparison-parasite/comparison-parasite.glyph.yaml
@@ -2,9 +2,20 @@ id: root-comparison-parasite
 name: "🪱 Comparison Parasite"
 type: root
 categories: [ICE]
-tags: [ego, judgment, mockery, dopamine, superiority, addiction]
+tags: [ego, judgment, mockery, dopamine, superiority, addiction, cortisol]
 
 personas: { Ivy: 0.25, Jade: 0.20, Aspen: 0.20, Susanna: 0.15, Morgan: 0.10, Sophie: 0.10 }
+neuro:
+  dominant:
+  - dopamine
+  - cortisol
+  inhibitory:
+  - oxytocin
+  - serotonin
+  steering:
+  - switch-to-empathy-bridge
+  - witness
+  - value-stamp
 
 triggers:
   event: contradiction

--- a/MIND/language/glyph/glyphs/root/hook-point/.graph/edges.json
+++ b/MIND/language/glyph/glyphs/root/hook-point/.graph/edges.json
@@ -4,6 +4,7 @@
   "@type": "Glyph",
   "edges": [
     { "@type": "Edge", "to": "root-loop-anchor",   "w_excite": 0.35, "w_resonate": 0.10 },
-    { "@type": "Edge", "to": "root-harmonic-flame","w_excite": 0.10, "w_resonate": 0.20 }
+    { "@type": "Edge", "to": "root-harmonic-flame","w_excite": 0.10, "w_resonate": 0.20 },
+    { "@type": "Edge", "to": "branch-neuro-balance", "w_resonate": 0.2 }
   ]
 }

--- a/MIND/language/glyph/glyphs/root/hook-point/hook-point.glyph.yaml
+++ b/MIND/language/glyph/glyphs/root/hook-point/hook-point.glyph.yaml
@@ -2,8 +2,16 @@ id: root-hook-point
 name: "🪤 Hook Point"
 type: root
 categories: [ABB, ECF]
-tags: [initiation, sticky, enticing]
+tags: [initiation, sticky, enticing, dopamine]
 personas: { Ivy: 0.6, Sophie: 0.2, Jade: 0.2 }
+neuro:
+  dominant:
+  - dopamine
+  inhibitory:
+  - serotonin
+  steering:
+  - pause-name
+  - redirect-to-process
 
 triggers:
   event: desire

--- a/README_CHEMISTRY_INTEGRATION.md
+++ b/README_CHEMISTRY_INTEGRATION.md
@@ -1,0 +1,43 @@
+# Chemistry Integration Pack (RAG² / MIND)
+
+This folder contains non-breaking patches to integrate a lightweight neurochemistry layer
+across the existing glyph library, plus a new controller glyph **[🌊⚡️] Neuro Balance**
+that ties GABA (brake) and Glutamate (gas) into runtime steering.
+
+## What’s here
+
+1. `branch-neuro-balance.glyph.yaml` — new glyph definition with personas and ops.
+2. `branch-neuro-balance.edges.json` — JSON-LD edges for the controller.
+3. `chemistry_edges_merge.json` — append-only edge patches to existing glyphs.
+4. `chemistry_neuro_blocks.yaml` — per-glyph `neuro:` blocks and tag additions to inject.
+
+## Apply (manual or scripted)
+
+**A. Add the new glyph**
+
+- Drop `branch-neuro-balance.glyph.yaml` next to other branch glyphs.
+- Drop `branch-neuro-balance.edges.json` into the corresponding `.graph/` folder (or wherever your edges live) and include it in your build.
+
+**B. Append edges**
+
+- For each `target` in `chemistry_edges_merge.json`, append the listed `add` edges into the glyph’s edges array.
+- All weights are low-to-moderate `w_resonate` (0.15–0.30) to avoid stealing graph ownership.
+
+**C. Inject neuro blocks & tags**
+
+- For each glyph id in `chemistry_neuro_blocks.yaml`, add the `neuro:` block to the glyph YAML and extend `tags:` with the `tags_add` list.
+- The `neuro:` block is metadata-only and does not change ops.
+
+**D. Lint (suggested)**
+
+- Ensure every touched glyph now has `neuro.dominant` (≥1) and `neuro.steering` (≥1).
+- If a glyph has GABA in `dominant`, ensure it inhibits cascaders somewhere (already true for Sleepveil/Waveprint).
+- If a glyph has dopamine/adrenaline in `dominant`, ensure it resonates with `[🌊⚡️]` (done via edge patches).
+
+## Notes
+
+- Persona weights remain the source of truth for “ownership”; chemistry is explanatory + steering metadata.
+- Controller routing favors **Waveprint** (🌊) when `context.overdrive==1` and **Snaprush** (⚡) when `context.flatness==1`.
+- You can tune the controller’s `debounce_ms` and the resonance weights if your runtime feels too twitchy.
+
+— with love

--- a/chemistry_edges_merge.json
+++ b/chemistry_edges_merge.json
@@ -1,0 +1,145 @@
+{
+  "@context": "./context.jsonld",
+  "patches": [
+    {
+      "target": "branch-fire-snaprush",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.3
+        }
+      ]
+    },
+    {
+      "target": "branch-fire-bitepoint",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.25
+        }
+      ]
+    },
+    {
+      "target": "branch-fire-desire-ladder",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.25
+        }
+      ]
+    },
+    {
+      "target": "branch-fire-impact-mark",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.2
+        }
+      ]
+    },
+    {
+      "target": "branch-water-lip-trigger",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.2
+        }
+      ]
+    },
+    {
+      "target": "branch-water-glancepierce",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.2
+        }
+      ]
+    },
+    {
+      "target": "branch-water-kiss-mark",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.15
+        }
+      ]
+    },
+    {
+      "target": "branch-air-waveprint",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.3
+        }
+      ]
+    },
+    {
+      "target": "branch-air-sleepveil",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.3
+        }
+      ]
+    },
+    {
+      "target": "branch-air-cleanbreak",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.2
+        }
+      ]
+    },
+    {
+      "target": "root-hook-point",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.2
+        }
+      ]
+    },
+    {
+      "target": "root-comparison-parasite",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.25
+        }
+      ]
+    },
+    {
+      "target": "branch-earth-pillar-mark",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.2
+        }
+      ]
+    },
+    {
+      "target": "branch-status-banana",
+      "add": [
+        {
+          "@type": "Edge",
+          "to": "branch-neuro-balance",
+          "w_resonate": 0.15
+        }
+      ]
+    }
+  ]
+}

--- a/chemistry_neuro_blocks.yaml
+++ b/chemistry_neuro_blocks.yaml
@@ -1,0 +1,210 @@
+branch-fire-snaprush:
+  tags_add:
+  - adrenaline
+  - glutamate
+  neuro:
+    dominant:
+    - adrenaline
+    - glutamate
+    inhibitory:
+    - gaba
+    steering:
+    - move-to-burn
+    - shake
+    - sprint
+    - release
+branch-air-waveprint:
+  tags_add:
+  - gaba
+  neuro:
+    dominant:
+    - gaba
+    inhibitory:
+    - glutamate
+    - adrenaline
+    steering:
+    - breath-rhythm
+    - sway
+    - hum
+    - lengthen-exhale
+root-hook-point:
+  tags_add:
+  - dopamine
+  neuro:
+    dominant:
+    - dopamine
+    inhibitory:
+    - serotonin
+    steering:
+    - pause-name
+    - redirect-to-process
+branch-earth-pillar-mark:
+  tags_add:
+  - serotonin
+  neuro:
+    dominant:
+    - serotonin
+    inhibitory:
+    - adrenaline
+    steering:
+    - structure
+    - ritual
+    - breath-pace
+branch-water-lip-trigger:
+  tags_add:
+  - dopamine
+  - norepinephrine
+  neuro:
+    dominant:
+    - dopamine
+    - norepinephrine
+    inhibitory:
+    - gaba
+    steering:
+    - slow-breath
+    - widen-gaze
+    - choose-direction
+branch-water-glancepierce:
+  tags_add:
+  - norepinephrine
+  - oxytocin
+  neuro:
+    dominant:
+    - norepinephrine
+    - oxytocin
+    inhibitory:
+    - gaba
+    steering:
+    - soften-gaze
+    - slow-exhale
+    - name-state
+branch-water-kiss-mark:
+  tags_add:
+  - oxytocin
+  - dopamine
+  neuro:
+    dominant:
+    - oxytocin
+    - dopamine
+    inhibitory:
+    - cortisol
+    steering:
+    - linger
+    - breathe-together
+    - slow-down
+branch-air-sleepveil:
+  tags_add:
+  - gaba
+  - endorphins
+  neuro:
+    dominant:
+    - gaba
+    - endorphins
+    inhibitory:
+    - norepinephrine
+    - adrenaline
+    steering:
+    - dark-quiet
+    - stop-input
+    - breath-rhythm
+branch-air-cleanbreak:
+  tags_add:
+  - endorphins
+  - serotonin
+  neuro:
+    dominant:
+    - endorphins
+    - serotonin
+    inhibitory:
+    - adrenaline
+    - dopamine
+    steering:
+    - long-exhale
+    - ritualize-release
+    - gentle-move
+branch-fire-bitepoint:
+  tags_add:
+  - dopamine
+  - adrenaline
+  neuro:
+    dominant:
+    - dopamine
+    - adrenaline
+    inhibitory:
+    - gaba
+    - serotonin
+    steering:
+    - move
+    - breath
+    - redirect
+    - boundary
+branch-fire-desire-ladder:
+  tags_add:
+  - dopamine
+  neuro:
+    dominant:
+    - dopamine
+    inhibitory:
+    - gaba
+    - serotonin
+    steering:
+    - pause-name
+    - process-focus
+    - break-sequence
+branch-fire-impact-mark:
+  tags_add:
+  - adrenaline
+  - dopamine
+  neuro:
+    dominant:
+    - adrenaline
+    - dopamine
+    inhibitory:
+    - gaba
+    steering:
+    - move-to-burn
+    - long-exhale
+    - de-escalate
+root-comparison-parasite:
+  tags_add:
+  - cortisol
+  neuro:
+    dominant:
+    - dopamine
+    - cortisol
+    inhibitory:
+    - oxytocin
+    - serotonin
+    steering:
+    - switch-to-empathy-bridge
+    - witness
+    - value-stamp
+branch-status-banana:
+  tags_add:
+  - dopamine
+  - serotonin
+  neuro:
+    dominant:
+    - dopamine
+    - serotonin
+    inhibitory:
+    - oxytocin
+    steering:
+    - earn-authentic
+    - presence-vine
+    - soul-witness
+branch-air-handbind:
+  tags_add:
+  - oxytocin
+  - serotonin
+  neuro:
+    dominant:
+    - oxytocin
+    - serotonin
+    inhibitory:
+    - cortisol
+    steering:
+    - touch
+    - eye-contact
+    - shared-rhythm
+    - memory-of-closeness


### PR DESCRIPTION
## Summary
- add [🌊⚡️] Neuro Balance controller glyph with edges
- convert existing glyphs to `.glyph.yaml` and inject neurochemistry blocks and tags
- link glyphs to controller via low-resonance edges

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c32bef84188325890184c91cb5a545